### PR TITLE
rdata should be an output, not input

### DIFF
--- a/peakrdl/verilog/templates/module.sv
+++ b/peakrdl/verilog/templates/module.sv
@@ -49,7 +49,7 @@ module {{get_inst_name(top_node)}} (
     input wire [ADDR_WIDTH-1:0]   addr;
     input wire [DATA_WIDTH-1:0]   wdata;
     input wire [DATA_WIDTH/8-1:0] wmask;
-    input wire [DATA_WIDTH-1:0]   rdata;
+    output wire [DATA_WIDTH-1:0]  rdata;
 
     reg [DATA_WIDTH-1:0] mask;
 


### PR DESCRIPTION
Fix just by looking at the generated Verilog output, haven't actually tried simulating this.
Should also fix the non-ANSI module definition to ANSI-style, but that will wait for a different PR.