### PR TITLE
Add busses folder to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include peakrdl/verilog/templates *
+recursive-include peakrdl/verilog/busses *
 recursive-exclude test *


### PR DESCRIPTION
I cloned the repo, and installed it with
pip install .

The busses folder wasn't copied to the site packages location, because
(I believe) it wasn't included in MANIFEST.in. This commit fixes that
condition.
After fixing the MANIFEST, I was able to generate output.
